### PR TITLE
【Fixed】ステップ11の対応

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,12 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
   def index
-    @tasks = Task.all
+    if params[:order] == "asc"
+      @order = "desc"
+    else
+      @order = "asc"
+    end
+    @tasks = Task.all.order(created_at: @order)
   end
 
   def show

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,6 +2,23 @@
 
 <h1><%= t('view.tasks.index') %></h1>
 
+<div>
+
+<table>
+  <tr>
+    <td><%= link_to t('view.tasks.link_to_new_task'), new_task_path %></td>
+    <td colspan="3"></td>
+    <td>
+      <% if @order == "asc" %>
+      <%   order_text = t('view.tasks.order_desc') %>
+      <% else  %>
+      <%   order_text = t('view.tasks.order_asc') %>
+      <% end %>
+      <%= link_to order_text, tasks_path(order: @order), id: "order_change" %>
+    </td>
+  </tr>
+</table>
+</div>
 <table>
   <thead>
     <tr>
@@ -10,10 +27,9 @@
       <th colspan="3"></th>
     </tr>
   </thead>
-
   <tbody>
     <% @tasks.each do |task| %>
-      <tr>
+      <tr class="task_list">
         <td><%= task.name %></td>
         <td><%= task.description %></td>
         <td><%= link_to t('view.tasks.link_to_show_task'), task %></td>
@@ -28,5 +44,3 @@
 </table>
 
 <br>
-
-<%= link_to t('view.tasks.link_to_new_task'), new_task_path %>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -10,3 +10,5 @@ ja:
       message_of_confirm_delete_task: タスクを削除してもよろしいですか？
       link_to_new_task: 新しいタスクを作成
       link_to_index_task: タスク一覧へ
+      order_asc: 作成日時で昇順
+      order_desc: 作成日時で降順

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,26 @@
+FactoryBot.define do
+
+  # 作成するテストデータの名前を「task」とします
+  # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
+  factory :task do
+    name { 'Factoryで作ったデフォルトのタイトル１' }
+    description { 'Factoryで作ったデフォルトのコンテント１' }
+  end
+
+  # 作成するテストデータの名前を「second_task」とします
+  # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
+  factory :second_task, class: Task do
+    name { 'Factoryで作ったデフォルトのタイトル２' }
+    description { 'Factoryで作ったデフォルトのコンテント２' }
+  end
+
+  factory :first_order_task, class: Task do
+    name { '最初に作成したタスク名first_order_task_name' }
+    description { '最初に作成したタスク詳細first_order_task_description' }
+  end
+
+  factory :last_order_task, class: Task do
+    name { '最後に作成したタスク名last_order_task_name' }
+    description { '最後に作成したタスク詳細last_order_task_description' }
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -3,11 +3,20 @@ require 'rails_helper'
 
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
+  background do
+    FactoryBot.create(:first_order_task)
+    FactoryBot.create(:task, name: 'task_name_01', description: 'test01testtest')
+    FactoryBot.create(:task, name: 'task_name_02', description: 'sample02sample')
+    FactoryBot.create(:task, name: 'task_name_08', description: 'test08testtest')
+    FactoryBot.create(:task, name: 'task_name_09', description: 'sample09sample')
+    FactoryBot.create(:second_task)
+    FactoryBot.create(:last_order_task)
+  end
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
-  scenario "タスク一覧のテストOKパターン" do
+  scenario "タスク一覧のテスト" do
     # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
-    Task.create!(name: 'task_name_01', description: 'test01testtest')
-    Task.create!(name: 'test_name_02', description: 'sample02sample')
+    # Task.create!(name: 'task_name_01', description: 'test01testtest')
+    # Task.create!(name: 'test_name_02', description: 'sample02sample')
 
     # tasks_pathにvisitする（タスク一覧ページに遷移する）
     visit tasks_path
@@ -56,12 +65,60 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     visit task_path(task.id)
 
-    # save_and_open_page
-
     expect(page).to have_content 'task_name_06'
     expect(page).to have_content 'test06testtest'
 
     expect(page).not_to have_content 'task_name_07'
     expect(page).not_to have_content 'test07testtest'
   end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+
+    # tasks_pathにvisitする（タスク一覧ページに遷移する）
+    visit tasks_path
+
+    # この時点でのタスクのリストを取得。
+    # この時点では作成日時が一番古いタスクが一番先頭になっているはず
+    task = all('.task_list')
+
+    # リストの一番先頭の行を取得
+    task_0 = task[0]
+
+    # リストの一番先頭の行が、作成日時が一番古いタスクであることを証明
+    expect(task_0).to have_content "最初に作成したタスク名first_order_task_name"
+    # リストの一番先頭の行が、作成日時が一番新しいタスクでないことを証明
+    expect(task_0).not_to have_content "最後に作成したタスク名last_order_task_name"
+
+    # "作成日時で降順"リンクをクリックする
+    click_link 'order_change'
+
+    # この時点でのタスクのリストを取得。
+    # この時点では作成日時が一番新しいタスクが一番先頭になっているはず
+    task = all('.task_list')
+
+    # リストの一番先頭の行を取得
+    task_0 = task[0]
+
+    # リストの一番先頭の行が、作成日時が一番新しいタスクであることを証明
+    expect(task_0).to have_content "最後に作成したタスク名last_order_task_name"
+    # リストの一番先頭の行が、作成日時が一番古いタスクでないことを証明
+    expect(task_0).not_to have_content "最初に作成したタスク名first_order_task_name"
+
+    # "作成日時で昇順"リンクをクリックする
+    click_link 'order_change'
+
+    # この時点でのタスクのリストを取得。
+    # この時点では作成日時が一番古いタスクが一番先頭になっているはず
+    task = all('.task_list')
+
+    # リストの一番先頭の行を取得
+    task_0 = task[0]
+
+    # リストの一番先頭の行が、作成日時が一番古いタスクであることを証明
+    expect(task_0).to have_content "最初に作成したタスク名first_order_task_name"
+    # リストの一番先頭の行が、作成日時が一番新しいタスクでないことを証明
+    expect(task_0).not_to have_content "最後に作成したタスク名last_order_task_name"
+
+     # save_and_open_page
+   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,9 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.before(:all) do
+    FactoryBot.reload
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
1.views/tasks/index.html.erb に、taskのリストの表示順を作成日時で降順/昇順に切り替えるリンクを追加
2. 上記1の対応に伴い、controllers/tasks_controller.rb を変更
3. 上記1の対応に伴い、config/locales/view.ja.yml を変更
4. spec/factories/task.rb, spec/features/task.spec.rb にテストコードを作成
5. テストコードを実行して、動作に問題がないことを確認

以上です。
